### PR TITLE
Fix related to Bold, Italic, Underline, and Strikethrough toolbar

### DIFF
--- a/src/VignetteCommand.test.ts
+++ b/src/VignetteCommand.test.ts
@@ -151,7 +151,7 @@ describe('VignetteCommand', () => {
   });
 
   test('isActive returns true', () => {
-    expect(cmd.isActive()).toBe(true);
+    expect(cmd.isActive()).toBe(false);
   });
 
   test('executeCustom returns tr unchanged', () => {

--- a/src/VignetteCommand.ts
+++ b/src/VignetteCommand.ts
@@ -136,7 +136,7 @@ export class VignetteCommand extends UICommand {
   }
 
   isActive(): boolean {
-    return true;
+    return false;
   }
   executeCustom(_state: EditorState, tr: Transform): Transform {
     return tr;


### PR DESCRIPTION
Fix related to Bold, Italic, Underline, and Strikethrough toolbar buttons do not visually reflect changes even when the formatting is applied to text